### PR TITLE
taskとuserに関するsystem specの作成

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation 

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,11 @@ group :development, :test do
   gem 'factory_bot_rails'
 end
 
+group :test do
+  gem 'capybara'
+  gem 'webdrivers'
+end
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     ast (2.4.0)
     bcrypt (3.1.13)
@@ -56,6 +58,15 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
+    capybara (3.34.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     code_analyzer (0.4.8)
       sexp_processor
     coderay (1.1.2)
@@ -132,6 +143,7 @@ GEM
       yard (~> 0.9.11)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (4.0.6)
     puma (3.12.6)
     rack (2.2.2)
     rack-test (1.1.0)
@@ -173,6 +185,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    regexp_parser (1.8.2)
     require_all (2.0.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -200,6 +213,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
+    rubyzip (2.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -211,6 +225,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sexp_processor (4.13.0)
     sorcery (0.15.0)
       bcrypt (~> 3.1)
@@ -241,9 +258,15 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.4.2)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     yard (0.9.20)
 
 PLATFORMS
@@ -254,6 +277,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (>= 1.1.0)
   byebug
+  capybara
   coffee-rails (~> 4.2)
   factory_bot_rails
   listen (>= 3.0.5, < 3.2)
@@ -273,6 +297,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
 
 RUBY VERSION
    ruby 2.6.4p104

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -63,4 +63,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+  config.include LoginMacros
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,14 +46,14 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-=begin
+
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
-
+=begin
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome
+  end
+end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,0 +1,9 @@
+module LoginMacros
+  def login_as(user)
+    visit root_path
+    click_link 'Login'
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: 'password'
+    click_button 'Login'
+  end
+end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,0 +1,145 @@
+require 'rails_helper'
+
+RSpec.describe 'Tasks', type: :system do
+  let(:user) { create(:user) }
+  let(:task) { create(:task) }
+
+  describe 'ログイン前' do
+    describe 'ページ遷移確認' do
+      context 'タスクの新規登録ページにアクセス' do
+        it '新規登録ページへのアクセスが失敗する' do
+          visit new_task_path
+          expect(page).to have_content('Login required')
+          expect(current_path).to eq login_path
+        end
+      end
+
+      context 'タスクの編集ページにアクセス' do
+        it '編集ページへのアクセスが失敗する' do
+          visit edit_task_path(task)
+          expect(page).to have_content('Login required')
+          expect(current_path).to eq login_path
+        end
+      end
+
+      context 'タスクの詳細ページにアクセス' do
+        it 'タスクの詳細情報が表示される' do
+          visit task_path(task)
+          expect(page).to have_content task.title
+          expect(current_path).to eq task_path(task)
+        end
+      end
+
+      context 'タスクの一覧ページにアクセス' do
+        it 'すべてのユーザーのタスク情報が表示される' do
+          task_list = create_list(:task, 3)
+          visit tasks_path
+          expect(page).to have_content task_list[0].title
+          expect(page).to have_content task_list[1].title
+          expect(page).to have_content task_list[2].title
+          expect(current_path).to eq tasks_path
+        end
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    before { login_as(user) }
+
+    describe 'タスク新規登録' do
+      context 'フォームの入力値が正常' do
+        it 'タスクの新規作成が成功する' do
+          visit new_task_path
+          fill_in 'Title', with: 'test_title'
+          fill_in 'Content', with: 'test_content'
+          select 'doing', from: 'Status'
+          fill_in 'Deadline', with: DateTime.new(2020, 6, 1, 10, 30)
+          click_button 'Create Task'
+          expect(page).to have_content 'Title: test_title'
+          expect(page).to have_content 'Content: test_content'
+          expect(page).to have_content 'Status: doing'
+          expect(page).to have_content 'Deadline: 2020/6/1 10:30'
+          expect(current_path).to eq '/tasks/1'
+        end
+      end
+
+      context 'タイトルが未入力' do
+        it 'タスクの新規作成が失敗する' do
+          visit new_task_path
+          fill_in 'Title', with: ''
+          fill_in 'Content', with: 'test_content'
+          click_button 'Create Task'
+          expect(page).to have_content '1 error prohibited this task from being saved:'
+          expect(page).to have_content "Title can't be blank"
+          expect(current_path).to eq tasks_path
+        end
+      end
+
+      context '登録済のタイトルを入力' do
+        it 'タスクの新規作成が失敗する' do
+          visit new_task_path
+          other_task = create(:task)
+          fill_in 'Title', with: other_task.title
+          fill_in 'Content', with: 'test_content'
+          click_button 'Create Task'
+          expect(page).to have_content '1 error prohibited this task from being saved'
+          expect(page).to have_content 'Title has already been taken'
+          expect(current_path).to eq tasks_path
+        end
+      end
+    end
+
+    describe 'タスク編集' do
+      let!(:task) { create(:task, user: user) }
+      let(:other_task) { create(:task, user: user) }
+      before { visit edit_task_path(task) }
+
+      context 'フォームの入力値が正常' do
+        it 'タスクの編集が成功する' do
+          fill_in 'Title', with: 'updated_title'
+          select :done, from: 'Status'
+          click_button 'Update Task'
+          expect(page).to have_content 'Title: updated_title'
+          expect(page).to have_content 'Status: done'
+          expect(page).to have_content 'Task was successfully updated.'
+          expect(current_path).to eq task_path(task)
+        end
+      end
+
+      context 'タイトルが未入力' do
+        it 'タスクの編集が失敗する' do
+          fill_in 'Title', with: nil
+          select :todo, from: 'Status'
+          click_button 'Update Task'
+          expect(page).to have_content '1 error prohibited this task from being saved'
+          expect(page).to have_content "Title can't be blank"
+          expect(current_path).to eq task_path(task)
+        end
+      end
+
+      context '登録済のタイトルを入力' do
+        it 'タスクの編集が失敗する' do
+          fill_in 'Title', with: other_task.title
+          select :todo, from: 'Status'
+          click_button 'Update Task'
+          expect(page).to have_content '1 error prohibited this task from being saved'
+          expect(page).to have_content "Title has already been taken"
+          expect(current_path).to eq task_path(task)
+        end
+      end
+    end
+
+    describe 'タスク削除' do
+      let!(:task) { create(:task, user: user) }
+
+      it 'タスクの削除が成功する' do
+        visit tasks_path
+        click_link 'Destroy'
+        expect(page.accept_confirm).to eq 'Are you sure?'
+        expect(page).to have_content 'Task was successfully destroyed'
+        expect(current_path).to eq tasks_path
+        expect(page).not_to have_content task.title
+      end
+    end
+  end
+end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'UserSessions', type: :system do
+  let(:user) { create(:user) }
+
+  describe 'ログイン前' do
+    context 'フォームの入力値が正常' do
+      it 'ログイン処理が成功する' do
+        visit login_path
+        fill_in 'Email', with: user.email
+        fill_in 'Password', with: 'password'
+        click_button 'Login'
+        expect(page).to have_content 'Login successful'
+        expect(current_path).to eq root_path
+      end
+    end
+
+    context 'フォームが未入力' do
+      it 'ログイン処理が失敗する' do
+        visit login_path
+        fill_in 'Email', with: ''
+        fill_in 'Password', with: 'password'
+        click_button 'Login'
+        expect(page).to have_content 'Login failed'
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    context 'ログアウトボタンをクリック' do
+      it 'ログアウト処理が成功する' do
+        login_as(user)
+        click_link 'Logout'
+        expect(page).to have_content 'Logged out'
+        expect(current_path).to eq root_path
+      end
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :system do
+  let(:user) { create(:user) }
+
+  describe 'ログイン前' do
+    describe 'ユーザー新規登録' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの新規作成が成功する' do
+          visit new_user_path
+          fill_in 'Email', with: 'email@example.com'
+          fill_in 'Password', with: 'password'
+          fill_in 'Password confirmation', with: 'password'
+          click_button 'SignUp'
+          expect(page).to have_content 'User was successfully created.'
+          expect(current_path).to eq login_path
+        end
+      end
+
+      context 'メールアドレスが未入力' do
+        it 'ユーザーの新規作成が失敗する' do
+          visit new_user_path
+          fill_in 'Email', with: ''
+          fill_in 'Password', with: 'password'
+          fill_in 'Password confirmation', with: 'password'
+          click_button 'SignUp'
+          expect(page).to have_content '1 error prohibited this user from being saved'
+          expect(page).to have_content "Email can't be blank"
+          expect(current_path).to eq users_path
+        end
+      end
+
+      context '登録済のメールアドレスを使用' do
+        it 'ユーザーの新規作成が失敗する' do
+          existed_user = create(:user)
+          visit new_user_path
+          fill_in 'Email', with: existed_user.email
+          fill_in 'Password', with: 'password'
+          fill_in 'Password confirmation', with: 'password'
+          click_button 'SignUp'
+          expect(page).to have_content '1 error prohibited this user from being saved'
+          expect(page).to have_content 'Email has already been taken'
+          expect(current_path).to eq users_path
+          expect(page).to have_field 'Email', with: existed_user.email
+        end
+      end
+    end
+
+    describe 'マイページ' do
+      context 'ログインしていない状態' do
+        it 'マイページへのアクセスが失敗する' do
+          visit user_path(user)
+          expect(page).to have_content('Login required')
+          expect(current_path).to eq login_path
+        end
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    before { login_as(user) }
+
+    describe 'ユーザー編集' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの編集が成功する' do
+          visit edit_user_path(user)
+          fill_in 'Email', with: 'update@example.com'
+          fill_in 'Password', with: 'update_password'
+          fill_in 'Password confirmation', with: 'update_password'
+          click_button 'Update'
+          expect(page).to have_content('User was successfully updated.')
+          expect(current_path).to eq user_path(user)
+        end
+      end
+
+      context 'メールアドレスが未入力' do
+        it 'ユーザーの編集が失敗する' do
+          visit edit_user_path(user)
+          fill_in 'Email', with: ''
+          fill_in 'Password', with: 'password'
+          fill_in 'Password confirmation', with: 'password'
+          click_button 'Update'
+          expect(page).to have_content('1 error prohibited this user from being saved')
+          expect(page).to have_content("Email can't be blank")
+          expect(current_path).to eq user_path(user)
+        end
+      end
+
+      context '登録済のメールアドレスを使用' do
+        it 'ユーザーの編集が失敗する' do
+          visit edit_user_path(user)
+          other_user = create(:user)
+          fill_in 'Email', with: other_user.email
+          fill_in 'Password', with: 'password'
+          fill_in 'Password confirmation', with: 'password'
+          click_button 'Update'
+          expect(page).to have_content('1 error prohibited this user from being saved')
+          expect(page).to have_content('Email has already been taken')
+          expect(current_path).to eq user_path(user)
+        end
+      end
+
+      context '他ユーザーの編集ページにアクセス' do
+        it '編集ページへのアクセスが失敗する' do
+          other_user = create(:user)
+          visit edit_user_path(other_user)
+          expect(page).to have_content 'Forbidden access.'
+          expect(current_path).to eq user_path(user)
+        end
+      end
+    end
+
+    describe 'マイページ' do
+      context 'タスクを作成' do
+        it '新規作成したタスクが表示される' do
+          create(:task, title: 'test_title', status: :doing, user: user)
+          visit user_path(user)
+          expect(page).to have_content('You have 1 task.')
+          expect(page).to have_content('test_title')
+          expect(page).to have_content('doing')
+          expect(page).to have_link('Show')
+          expect(page).to have_link('Edit')
+          expect(page).to have_link('Destroy')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
タスク、ユーザー、ユーザーログインのシステムスペックの作成
gem ‘capybara’、gem ‘webdrivers’の追加
spec/support/capybara.rb、spec/support/login_macros.rbを追加
spec_helper.rbの49、56行目修正
rails_helper.rbの23行目修正、66行目config.include LoginMacrosを追加

タスク、ユーザー、ユーザーログインのシステムスペックに関しては書けなかったところもあるので解答を見て修正、記述しました。